### PR TITLE
Fix list of languages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,24 @@ All issues are open issues. If there are multiple PR's trying to solve an issue,
 
 ## Implemented Languages List:
 <details>
-- Bash
--	C
-- C++
-- C#
--	Python
--	Kotlin
--	PHP
--	Go
-- Julia
-- R
-- Assembly
--	Java
-- Typescript
--	JavaScript
+
+- [Assembly](https://github.com/rustiever/Hello-World/blob/main/hello_world.asm)
+- [Bash](https://github.com/rustiever/Hello-World/blob/main/hello_world.sh)
+- [C](https://github.com/rustiever/Hello-World/blob/main/hello_world.c)
+- [C++](https://github.com/rustiever/Hello-World/blob/main/hello_world.cpp)
+- [C#](https://github.com/rustiever/Hello-World/blob/main/hello_world.cs)
+- [Clojure](https://github.com/rustiever/Hello-World/blob/main/hello_world.clj)
+- [Dart](https://github.com/rustiever/Hello-World/blob/main/hello_world.dart)
+- [Go](https://github.com/rustiever/Hello-World/blob/main/hello_world.go)
+- [Java](https://github.com/rustiever/Hello-World/blob/main/hello_world.java)
+- [JavaScript](https://github.com/rustiever/Hello-World/blob/main/hello_world.js)
+- [Julia](https://github.com/rustiever/Hello-World/blob/main/hello_world.jl)
+- [Kotlin](https://github.com/rustiever/Hello-World/blob/main/hello_world.kt)
+- [PHP](https://github.com/rustiever/Hello-World/blob/main/hello_world.php)
+- [Python](https://github.com/rustiever/Hello-World/blob/main/hello_world.py)
+- [R](https://github.com/rustiever/Hello-World/blob/main/hello_world.R)
+- [Swift](https://github.com/rustiever/Hello-World/blob/main/hello_world.swift)
+- [Typescript](https://github.com/rustiever/Hello-World/blob/main/hello_world.ts)
 </details>
+
+


### PR DESCRIPTION
Hello again,  rustiever .

I was thinking that the languages in the README was a little messy, so decided to put it in alphabetical order and added links to respectively language example.
I think that it could be a good measure to put this instructions in the Contribution file too, so you can keep things in order

Best Regards